### PR TITLE
Restrict maximum nesting of groups

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -5,14 +5,22 @@
         <label for="ctrlEnableDragNDrop">
           Allow Drag'n'drop
         </label>
-        <input type="checkbox" v-model="ctrlEnableDragNDrop" id="ctrlEnableDragNDrop">
+        <input
+          type="checkbox"
+          v-model="ctrlEnableDragNDrop"
+          id="ctrlEnableDragNDrop"
+        >
       </div>
       <div class="container-config-item config-max-depth">
         <div>
           <label for="ctrlEnableMaxDepth">
             Enable max depth
           </label>
-          <input type="checkbox" v-model="ctrlEnableMaxDepth" id="ctrlEnableMaxDepth">
+          <input
+            type="checkbox"
+            v-model="ctrlEnableMaxDepth"
+            id="ctrlEnableMaxDepth"
+          >
         </div>
         <div>
           <label for="ctrlMaxDepth">
@@ -27,13 +35,48 @@
           >
         </div>
       </div>
+      <div class="container-config-item config-slots">
+        <div>
+          <label for="ctrlEnableGroupOperatorSlot">
+            Enable Group Operator Slot
+          </label>
+          <input
+            type="checkbox"
+            v-model="ctrlEnableGroupOperatorSlot"
+            id="ctrlEnableGroupOperatorSlot"
+          >
+        </div>
+        <div>
+          <label for="ctrlEnableGroupControlSlot">
+            Enable Group Control Slot
+          </label>
+          <input
+            type="checkbox"
+            v-model="ctrlEnableGroupControlSlot"
+            id="ctrlEnableGroupControlSlot"
+          >
+        </div>
+        <div>
+          <label for="ctrlEnableRuleSlot">
+            Enable Rule Slot
+          </label>
+          <input
+            type="checkbox"
+            v-model="ctrlEnableRuleSlot"
+            id="ctrlEnableRuleSlot"
+          >
+        </div>
+      </div>
     </div>
     <query-builder
       :config="getConfig"
       v-model="query"
       class ="query-builder"
     >
-      <template #groupOperator="props">
+      <template
+        v-if="ctrlEnableGroupOperatorSlot"
+        #groupOperator="props"
+      >
         <div class="query-builder-group-slot__group-selection">
           <span class="query-builder-group-slot__group-operator">SLOT #groupOperator</span>
           <select
@@ -51,11 +94,17 @@
         </div>
       </template>
 
-      <template #groupControl="props">
+      <template
+        v-if="ctrlEnableGroupControlSlot"
+        #groupControl="props"
+      >
         <group-ctrl-slot :group-ctrl="props"/>
       </template>
 
-      <template #rule="props">
+      <template
+        v-if="ctrlEnableRuleSlot"
+        #rule="props"
+      >
         <rule-slot :ruleCtrl="props"/>
       </template>
     </query-builder>
@@ -86,6 +135,12 @@ ctrlEnableDragNDrop: boolean = true;
   ctrlEnableMaxDepth: boolean = false;
 
   ctrlMaxDepth: number = 3;
+
+  ctrlEnableGroupOperatorSlot: boolean = true;
+
+  ctrlEnableGroupControlSlot: boolean = true;
+
+  ctrlEnableRuleSlot: boolean = true;
 
   query: RuleSet | null = {
     operatorIdentifier: 'OR',
@@ -235,7 +290,7 @@ body {
   margin-bottom: 30px;
   padding: 10px;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
 }
 
 // .container-config-item {

--- a/dev/App.vue
+++ b/dev/App.vue
@@ -1,8 +1,37 @@
 <template>
-  <div id="app">
+  <div class="container">
+    <div class="container-config">
+      <div class="container-config-item" >
+        <label for="ctrlEnableDragNDrop">
+          Allow Drag'n'drop
+        </label>
+        <input type="checkbox" v-model="ctrlEnableDragNDrop" id="ctrlEnableDragNDrop">
+      </div>
+      <div class="container-config-item config-max-depth">
+        <div>
+          <label for="ctrlEnableMaxDepth">
+            Enable max depth
+          </label>
+          <input type="checkbox" v-model="ctrlEnableMaxDepth" id="ctrlEnableMaxDepth">
+        </div>
+        <div>
+          <label for="ctrlMaxDepth">
+            Max Depth:
+          </label>
+          <input
+            v-model.number="ctrlMaxDepth"
+            type="number"
+            min="0"
+            :disabled="! ctrlEnableMaxDepth"
+            id="ctrlMaxDepth"
+          >
+        </div>
+      </div>
+    </div>
     <query-builder
-      :config="config"
+      :config="getConfig"
       v-model="query"
+      class ="query-builder"
     >
       <template #groupOperator="props">
         <div class="query-builder-group-slot__group-selection">
@@ -52,9 +81,19 @@ import RuleSlot from './RuleSlot.vue';
   },
 })
 export default class App extends Vue {
+ctrlEnableDragNDrop: boolean = true;
+
+  ctrlEnableMaxDepth: boolean = false;
+
+  ctrlMaxDepth: number = 3;
+
   query: RuleSet | null = {
     operatorIdentifier: 'OR',
     children: [
+      {
+        identifier: 'txt',
+        value: 'A',
+      },
       {
         operatorIdentifier: 'AND',
         children: [
@@ -143,7 +182,7 @@ export default class App extends Vue {
         initialValue: 10,
       },
     ],
-    maxDepth: 2,
+    maxDepth: undefined,
     colors: [
       'hsl(88, 50%, 55%)',
       'hsl(187, 100%, 45%)',
@@ -154,6 +193,22 @@ export default class App extends Vue {
       disabled: false,
       ghostClass: 'ghost',
     },
+  }
+
+  get getConfig(): QueryBuilderConfig {
+    const config: QueryBuilderConfig = { ...this.config };
+
+    if (!config.dragging) {
+      config.dragging = {};
+    }
+    config.dragging.disabled = !this.ctrlEnableDragNDrop;
+
+    config.maxDepth = Math.abs(this.ctrlMaxDepth || 0);
+    if (!this.ctrlEnableMaxDepth) {
+      config.maxDepth = undefined;
+    }
+
+    return config;
   }
 }
 </script>
@@ -168,9 +223,30 @@ body {
   font-size: 16px;
 }
 
-#app {
-  margin: 30px auto;
+.container {
   width: 90%;
+  margin: 30px auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.container-config {
+  border: 1px solid hsl(0, 0%, 75%);
+  margin-bottom: 30px;
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+// .container-config-item {
+//
+// }
+
+.config-max-depth #ctrlMaxDepth {
+  width: 70px;
+}
+
+.query-builder {
   border: 1px solid hsl(0, 0%, 75%);
 }
 

--- a/dev/App.vue
+++ b/dev/App.vue
@@ -143,6 +143,7 @@ export default class App extends Vue {
         initialValue: 10,
       },
     ],
+    maxDepth: 2,
     colors: [
       'hsl(88, 50%, 55%)',
       'hsl(187, 100%, 45%)',

--- a/dev/GroupCtrlSlot.vue
+++ b/dev/GroupCtrlSlot.vue
@@ -32,13 +32,15 @@ export default class GroupCtrlSlot extends Vue {
     >
       Add Rule
     </button>
-    <div class="query-builder-group-slot__spacer"/>
-    <button
-      @click="groupCtrl.newGroup"
-      class="query-builder-group-slot__group-adding-button"
-    >
-      Add Group
-    </button>
+    <template v-if="! groupCtrl.maxDepthExeeded">
+      <div class="query-builder-group-slot__spacer"/>
+      <button
+        @click="groupCtrl.newGroup"
+        class="query-builder-group-slot__group-adding-button"
+      >
+        Add Group
+      </button>
+    </template>
   </div>
 </template>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ Vue.component('NumberSelection', {
 
 ## Colors
 
-A complex, deep nested query can quickly become confusing. In order to keep an overview, nested
+A complex, deep nested query, can quickly become confusing. In order to keep an overview, nested
 groups may be emphasized with colorful hints.
 
 The `colors` property should be a string array with a minimum length of at least 2, containing any
@@ -229,7 +229,7 @@ for allowing nested dragging.
 If `typeof maxDepth === 'undefined'`, users may have an arbitrary depth of nested groups.
 
 For `typeof maxDepth === 'number' and 0 <= n <= maxDepth`, users are only allowed to create up to n
-groups in deep. If n is 0, users are effectively not allowed to create any groups at all.
+nested groups. If n is 0, users are effectively not allowed to create any groups at all.
 
 
 ### Runtime change
@@ -239,7 +239,7 @@ As a special chase, if the given query has a higher nested depth and a config ch
 `maxDepth` to a lower depth, the library (intentionally) removes any child groups, exceeding the
 present config limit. This ensures consistency with the `maxDepth` policy. It's the component user's
 responsibility of checking if setting `maxDepth` may not result in an unwanted side-effect of
-removing any children from the given query tree.
+removing any child-groups from the given query tree.
 
 
 ### Usage of Sortable
@@ -250,9 +250,9 @@ be violated and prevents dropping. The user will notice that the drag'n'drop pre
 as usually expected.
 
 
-### Usage of GroupCtrlSlotProps
+### Usage of groupCtrlSlotProps
 
-For the slot of type `GroupCtrlSlotProps`, the `newGroup()` callback, passed as slot prop, becomes a
-noop, if a group has exceeded the `maxDepth` policy. Additionally, a boolean flag with as
-`maxDepthExeeded` property is provided to the slot prop object, so the slot can apply some v-if
-condition logic for hiding a create-new-group handler.
+For the slot of type [`groupCtrlSlotProps`](styling.html#groupcontrol-slot), the `newGroup()`
+callback, passed as slot prop, becomes a noop, if a group has exceeded the `maxDepth` policy.
+Additionally, a boolean flag with a `maxDepthExeeded` property is provided to the slot prop object,
+so the slot can check and hide a create-new-group handler.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,7 +158,7 @@ Vue.component('NumberSelection', {
 A complex, deep nested query can quickly become confusing. In order to keep an overview, nested
 groups may be emphasized with colorful hints.
 
-The colors property should be a string array with a minimum length of at least 2, containing any
+The `colors` property should be a string array with a minimum length of at least 2, containing any
 valid CSS color definition.
 
 
@@ -222,3 +222,37 @@ for allowing nested dragging.
   allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
+
+
+## Max-Depth
+
+If `typeof maxDepth === 'undefined'`, users may have an arbitrary depth of nested groups.
+
+For `typeof maxDepth === 'number' and 0 <= n <= maxDepth`, users are only allowed to create up to n
+groups in deep. If n is 0, users are effectively not allowed to create any groups at all.
+
+
+### Runtime change
+
+It is possible and valid to change `maxDepth` at runtime.
+As a special chase, if the given query has a higher nested depth and a config change restricts the
+`maxDepth` to a lower depth, the library (intentionally) removes any child groups, exceeding the
+present config limit. This ensures consistency with the `maxDepth` policy. It's the component user's
+responsibility of checking if setting `maxDepth` may not result in an unwanted side-effect of
+removing any children from the given query tree.
+
+
+### Usage of Sortable
+
+If drag'n'drop is activated via [Sortable](#sortable) config:
+Prior dropping a dragged group into another group, the library checks if the max depth policy would
+be violated and prevents dropping. The user will notice that the drag'n'drop preview will not adjust
+as usually expected.
+
+
+### Usage of GroupCtrlSlotProps
+
+For the slot of type `GroupCtrlSlotProps`, the `newGroup()` callback, passed as slot prop, becomes a
+noop, if a group has exceeded the `maxDepth` policy. Additionally, a boolean flag with as
+`maxDepthExeeded` property is provided to the slot prop object, so the slot can apply some v-if
+condition logic for hiding a create-new-group handler.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -23,7 +23,7 @@ Often, you'll have to use `v-bind:value` and `v-on:input` instead.
 The `groupOperator` slot may be used for changing the markup of a group's operator.
 
 The slot receives an object with the shape of the [GroupOperatorSlotProps
-object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts#L33).
+object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts#L34).
 
 ```vue
 <template>
@@ -73,7 +73,7 @@ object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts
 The `groupControl` slot allows for creating a new group or adding a new rule.
 
 The slot receives an object with the shape of the [GroupCtrlSlotProps
-object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts#L39).
+object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts#L40).
 
 <iframe
   src="https://codesandbox.io/embed/groupcontrol-slot-8thx1?fontsize=14&hidenavigation=1&module=%2Fsrc%2FApp.vue&theme=dark"
@@ -89,7 +89,7 @@ object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts
 The `rule` slot allows for customizing markup around each rule component.
 
 The slot receives an object with the shape of the [RuleSlotProps
-object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts#L45).
+object](https://github.com/rtucek/vue-query-builder/blob/master/types/index.d.ts#L47).
 
 You'll have to use Vue's [Dynamic
 Component](https://vuejs.org/v2/guide/components.html#Dynamic-Components) feature for displaying the

--- a/src/QueryBuilderGroup.vue
+++ b/src/QueryBuilderGroup.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  Component, Vue, Prop, Inject,
+  Component, Vue, Prop, Inject, Watch,
 } from 'vue-property-decorator';
 import Draggable, {
   ChangeEvent, Moved, Added, Removed,
@@ -31,6 +31,35 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
   @Prop() readonly depth!: number
 
   @Inject() readonly getMergeTrap!: () => MergeTrap
+
+  @Watch('query')
+  watchQuery() {
+    this.pruneChildren();
+  }
+
+  @Watch('config.maxDepth')
+  watchMaxDepth() {
+    this.pruneChildren();
+  }
+
+  mounted() {
+    this.pruneChildren();
+  }
+
+  pruneChildren() {
+    if (this.children.length !== this.query.children.length) {
+      // We've more groups as children, then allowed by the max policy.
+      const children = [...this.children];
+
+      this.$emit(
+        'query-update',
+        {
+          operatorIdentifier: this.selectedOperator,
+          children,
+        } as RuleSet,
+      );
+    }
+  }
 
   get selectedOperator(): string {
     return this.query.operatorIdentifier;

--- a/src/QueryBuilderGroup.vue
+++ b/src/QueryBuilderGroup.vue
@@ -10,7 +10,7 @@ import {
   QueryBuilderConfig, RuleSet, Rule, OperatorDefinition, RuleDefinition,
   GroupOperatorSlotProps, GroupCtrlSlotProps, QueryBuilderGroup as QueryBuilderGroupInterface,
 } from '@/types';
-import { isQueryBuilderConfig } from '@/guards';
+import { isQueryBuilderConfig, isRule } from '@/guards';
 import MergeTrap from '@/MergeTrap';
 import QueryBuilderChild from './QueryBuilderChild.vue';
 
@@ -51,6 +51,11 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
   selectedRule: string = ''
 
   get children(): Array<RuleSet | Rule> {
+    if (this.maxDepthExeeded) {
+      // filter children exclusively
+      return [...this.query.children].filter(isRule);
+    }
+
     return [...this.query.children];
   }
 
@@ -134,6 +139,14 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
 
   get childDepthClass(): string {
     return `query-builder-group__group-children--depth-${this.childDepth}`;
+  }
+
+  get maxDepthExeeded(): boolean {
+    if (typeof this.config.maxDepth !== 'number') {
+      return false;
+    }
+
+    return this.depth >= this.config.maxDepth;
   }
 
   get borderColor(): string {
@@ -346,13 +359,15 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
           >
             Add Rule
           </button>
-          <div class="query-builder-group__spacer"/>
-          <button
-            @click="newGroup"
-            class="query-builder-group__group-adding-button"
-          >
-            Add Group
-          </button>
+          <template v-if="! maxDepthExeeded">
+            <div class="query-builder-group__spacer"/>
+            <button
+              @click="newGroup"
+              class="query-builder-group__group-adding-button"
+            >
+              Add Group
+            </button>
+          </template>
         </div>
       </template>
     </div>

--- a/src/QueryBuilderGroup.vue
+++ b/src/QueryBuilderGroup.vue
@@ -184,6 +184,7 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
 
   get groupControlSlotProps(): GroupCtrlSlotProps {
     return {
+      maxDepthExeeded: this.maxDepthExeeded,
       rules: this.rules,
       addRule: (newRule: string) => {
         const currentRule = this.selectedRule;
@@ -249,6 +250,11 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
   }
 
   newGroup(): void {
+    if (this.maxDepthExeeded) {
+      // noop, as max depth reached
+      return;
+    }
+
     const children = [...this.children];
     children.push({
       operatorIdentifier: this.config.operators[0].identifier,

--- a/src/QueryBuilderGroup.vue
+++ b/src/QueryBuilderGroup.vue
@@ -47,18 +47,20 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
   }
 
   pruneChildren() {
-    if (this.children.length !== this.query.children.length) {
-      // We've more groups as children, then allowed by the max policy.
-      const children = [...this.children];
+    if (this.children.length === this.query.children.length) {
+      return;
+    }
 
-      this.$emit(
-        'query-update',
+    // We've more groups as children, then allowed by the max policy.
+    const children = [...this.children];
+
+    this.$emit(
+      'query-update',
         {
           operatorIdentifier: this.selectedOperator,
           children,
         } as RuleSet,
-      );
-    }
+    );
   }
 
   get selectedOperator(): string {

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -72,5 +72,6 @@ export function isQueryBuilderConfig(param: any): param is QueryBuilderConfig {
         Array.isArray(param.colors)
           && param.colors.every((color: any) => typeof color === 'string')
       )
-    );
+    )
+    && (['undefined', 'number'].includes(typeof param.maxDepth));
 }

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -73,5 +73,11 @@ export function isQueryBuilderConfig(param: any): param is QueryBuilderConfig {
           && param.colors.every((color: any) => typeof color === 'string')
       )
     )
-    && (['undefined', 'number'].includes(typeof param.maxDepth));
+    && (
+      typeof param.maxDepth === 'undefined' // optional config value not present
+      || (
+        typeof param.maxDepth === 'number'
+          && param.maxDepth >= 0
+      )
+    );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface GroupOperatorSlotProps {
 }
 
 export interface GroupCtrlSlotProps {
+  maxDepthExeeded: boolean,
   rules: RuleDefinition[],
   addRule: (newRule: string) => void,
   newGroup: () => void,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface RuleDefinition {
 export interface QueryBuilderConfig {
   operators: OperatorDefinition[],
   rules: RuleDefinition[],
+  maxDepth?: number,
   colors?: string[],
   dragging?: SortableOptions,
 }

--- a/tests/unit/max-depth.spec.ts
+++ b/tests/unit/max-depth.spec.ts
@@ -161,14 +161,14 @@ describe('Testing max-depth behaviour', () => {
     const group1 = (
         groups.filter(g => g.vm.$props.depth === 1)
           .shift()
-      ) as Wrapper<QueryBuilder, Element>;
+      ) as Wrapper<QueryBuilderGroupInstance, Element>;
     expect((group1.vm as QueryBuilderGroupInstance).maxDepthExeeded).toBeFalsy();
     expect(group1.find('.query-builder-group__group-adding-button').exists()).toBeTruthy();
 
     const group4 = (
         groups.filter(g => g.vm.$props.depth === 4)
           .shift()
-      ) as Wrapper<QueryBuilder, Element>;
+      ) as Wrapper<QueryBuilderGroupInstance, Element>;
     expect((group4.vm as QueryBuilderGroupInstance).maxDepthExeeded).toBeTruthy();
     expect(group4.find('.query-builder-group__group-adding-button').exists()).toBeFalsy();
   });
@@ -218,7 +218,7 @@ function buildDragEl(r: Rule | RuleSet, config: QueryBuilderConfig): HTMLElement
 }
 
 function buildDragOptions(ws: Array<Wrapper<Vue, Element>>): DragOptionsInterface {
-  const w = ws.shift() as Wrapper<QueryBuilder, Element>;
+  const w = ws.shift() as Wrapper<Vue, Element>;
   const qbgi = w.vm as QueryBuilderGroupInstance;
 
   return (qbgi.dragOptions as DragOptionsInterface);

--- a/tests/unit/max-depth.spec.ts
+++ b/tests/unit/max-depth.spec.ts
@@ -1,0 +1,225 @@
+import { mount, shallowMount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import Sortable, {
+  GroupOptions, PutResult, SortableEvent, SortableOptions,
+} from 'sortablejs';
+import QueryBuilder from '@/QueryBuilder.vue';
+import QueryBuilderGroup from '@/QueryBuilderGroup.vue';
+import QueryBuilderChild from '@/QueryBuilderChild.vue';
+import { RuleSet, QueryBuilderConfig, Rule } from '@/types';
+import Component from '../components/Component.vue';
+
+interface QueryBuilderGroupInstance extends Vue {
+  maxDepthExeeded: boolean,
+  dragOptions: SortableOptions,
+}
+
+interface GroupOptionsInterface extends GroupOptions {
+  put: ((to: Sortable, from: Sortable, dragEl: HTMLElement, event: SortableEvent) => PutResult)
+}
+
+interface DragOptionsInterface extends SortableOptions {
+  group: GroupOptionsInterface,
+}
+
+describe('Testing max-depth behaviour', () => {
+  const value: RuleSet = {
+    operatorIdentifier: 'OR',
+    children: [{
+      operatorIdentifier: 'AND',
+      children: [{
+        identifier: 'txt',
+        value: 'A',
+      }, {
+        identifier: 'txt',
+        value: 'B',
+      }, {
+        identifier: 'txt',
+        value: 'C',
+      }, {
+        operatorIdentifier: 'AND',
+        children: [{
+          identifier: 'txt',
+          value: 'D',
+        }, {
+          identifier: 'txt',
+          value: 'E',
+        }, {
+          operatorIdentifier: 'AND',
+          children: [{
+            identifier: 'txt',
+            value: 'F',
+          }, {
+            operatorIdentifier: 'AND',
+            children: [{
+              identifier: 'txt',
+              value: 'G',
+            }],
+          }, {
+            identifier: 'txt',
+            value: 'H',
+          }],
+        }],
+      }],
+    }, {
+      operatorIdentifier: 'AND',
+      children: [{
+        identifier: 'txt',
+        value: 'X',
+      }, {
+        operatorIdentifier: 'AND',
+        children: [{
+          identifier: 'txt',
+          value: 'T',
+        }],
+      }, {
+        identifier: 'txt',
+        value: 'Y',
+      }, {
+        identifier: 'txt',
+        value: 'Z',
+      }],
+    }],
+  };
+
+  const config: QueryBuilderConfig = {
+    operators: [
+      {
+        name: 'AND',
+        identifier: 'AND',
+      },
+      {
+        name: 'OR',
+        identifier: 'OR',
+      },
+    ],
+    rules: [
+      {
+        identifier: 'txt',
+        name: 'Text Selection',
+        component: Component,
+        initialValue: '',
+      },
+      {
+        identifier: 'num',
+        name: 'Number Selection',
+        component: Component,
+        initialValue: 10,
+      },
+    ],
+    dragging: {
+      animation: 300,
+      disabled: false,
+      ghostClass: 'ghost',
+    },
+    maxDepth: 4,
+  };
+
+  it('prunes existing branches which are beyond the max-depth setting', async () => {
+    const app = mount(QueryBuilder, {
+      propsData: {
+        value: { ...value },
+        config: { ...config },
+      },
+    });
+
+    const wrapper = app.findComponent(QueryBuilder);
+
+    // Before, ensure nothing has been changed
+    expect(wrapper.vm.$props.value).toHaveProperty('children.0.children.3.children.2.children.1.children.0.value', 'G');
+    expect(app.emitted('input')).toBeUndefined();
+
+    // Reduce max depth
+    await app.setProps({
+      value: { ...value },
+      config: { ...config, maxDepth: 3 },
+    });
+    expect(app.emitted('input')).toHaveLength(1);
+    expect((app.emitted('input') as any[])[0]).not.toHaveProperty('0.children.0.children.3.children.2.children.1.children.0.value', 'G');
+    expect((app.emitted('input') as any[])[0][0].children[0].children[3].children[2].children).toHaveLength(2);
+    expect((app.emitted('input') as any[])[0]).toHaveProperty('0.children.0.children.3.children.2.children', [{ identifier: 'txt', value: 'F' }, { identifier: 'txt', value: 'H' }]);
+
+    // Don't allow any group children
+    await app.setProps({
+      value: { ...value },
+      config: { ...config, maxDepth: 0 },
+    });
+
+    expect((app.emitted('input') as any[]).pop()[0].children).toHaveLength(0);
+  });
+
+  it('asserts no additional group can be created, beyond the mad-depth setting', () => {
+    const app = mount(QueryBuilder, {
+      propsData: {
+        value: { ...value },
+        config: { ...config },
+      },
+    });
+
+    const groups = app.findAllComponents(QueryBuilderGroup).wrappers;
+
+    const group1 = (
+        groups.filter(g => g.vm.$props.depth === 1)
+          .shift()
+      ) as Wrapper<QueryBuilder, Element>;
+    expect((group1.vm as QueryBuilderGroupInstance).maxDepthExeeded).toBeFalsy();
+    expect(group1.find('.query-builder-group__group-adding-button').exists()).toBeTruthy();
+
+    const group4 = (
+        groups.filter(g => g.vm.$props.depth === 4)
+          .shift()
+      ) as Wrapper<QueryBuilder, Element>;
+    expect((group4.vm as QueryBuilderGroupInstance).maxDepthExeeded).toBeTruthy();
+    expect(group4.find('.query-builder-group__group-adding-button').exists()).toBeFalsy();
+  });
+
+  it('checks and rejects movements, violating the max depth policy', () => {
+    const app = mount(QueryBuilder, {
+      propsData: {
+        value: { ...value },
+        config: { ...config },
+      },
+    });
+
+    const groups = app.findAllComponents(QueryBuilderGroup).wrappers;
+    const s = (null as never) as Sortable;
+    const se = (null as never) as SortableEvent;
+
+    // Moving rule is always fine
+    const movingRule = (value as any)
+      .children[0].children[3].children[2].children[1].children[0] as Rule | RuleSet;
+
+    const dragOptions1 = buildDragOptions(groups.filter(g => g.vm.$props.depth === 1));
+    expect(dragOptions1.group.put(s, s, buildDragEl(movingRule, config), se)).toBeTruthy();
+
+    const dragOptions2 = buildDragOptions(groups.filter(g => g.vm.$props.depth === 4));
+    expect(dragOptions2.group.put(s, s, buildDragEl(movingRule, config), se)).toBeTruthy();
+
+    // Moving ruleset needs extra check
+    const movingRuleSet = (value as any).children[1] as Rule | RuleSet;
+    expect(dragOptions1.group.put(s, s, buildDragEl(movingRuleSet, config), se)).toBeTruthy();
+    expect(dragOptions2.group.put(s, s, buildDragEl(movingRuleSet, config), se)).toBeFalsy();
+  });
+});
+
+function buildDragEl(r: Rule | RuleSet, config: QueryBuilderConfig): HTMLElement {
+  const rChild = shallowMount(QueryBuilderChild, {
+    propsData: {
+      query: { ...r },
+      config: { ...config },
+    },
+  });
+
+  const rEl = {
+    __vue__: rChild.vm,
+  } as unknown;
+
+  return rEl as HTMLElement;
+}
+
+function buildDragOptions(ws: Array<Wrapper<Vue, Element>>): DragOptionsInterface {
+  const w = ws.shift() as Wrapper<QueryBuilder, Element>;
+  const qbgi = w.vm as QueryBuilderGroupInstance;
+
+  return (qbgi.dragOptions as DragOptionsInterface);
+}

--- a/tests/unit/max-depth.spec.ts
+++ b/tests/unit/max-depth.spec.ts
@@ -11,19 +11,19 @@ import {
 } from '@/types';
 import Component from '../components/Component.vue';
 
-interface QueryBuilderGroupInstance extends Vue {
+interface QueryBuilderGroupInterface extends Vue {
   depth: number,
   maxDepthExeeded: boolean,
   dragOptions: SortableOptions,
   groupControlSlotProps: GroupCtrlSlotProps,
 }
 
-interface GroupOptionsInstance extends GroupOptions {
+interface GroupOptionsInterface extends GroupOptions {
   put: ((to: Sortable, from: Sortable, dragEl: HTMLElement, event: SortableEvent) => PutResult)
 }
 
 interface DragOptionsInstance extends SortableOptions {
-  group: GroupOptionsInstance,
+  group: GroupOptionsInterface,
 }
 
 describe('Testing max-depth behaviour', () => {
@@ -132,7 +132,7 @@ describe('Testing max-depth behaviour', () => {
     let group = app.findAllComponents(QueryBuilderGroup)
       .wrappers
       .filter(g => g.vm.$props.depth === 3)
-      .shift() as Wrapper<QueryBuilderGroupInstance, Element>;
+      .shift() as Wrapper<QueryBuilderGroupInterface, Element>;
     // Assert button is present
     let button = group.find('.query-builder-group__group-adding-button');
     expect(button.exists()).toBeTruthy();
@@ -145,7 +145,7 @@ describe('Testing max-depth behaviour', () => {
     group = app.findAllComponents(QueryBuilderGroup)
       .wrappers
       .filter(g => g.vm.$props.depth === 4)
-      .shift() as Wrapper<QueryBuilderGroupInstance, Element>;
+      .shift() as Wrapper<QueryBuilderGroupInterface, Element>;
     // Assert button is absent
     button = group.find('.query-builder-group__group-adding-button');
     expect(button.exists()).toBeFalsy();
@@ -196,7 +196,7 @@ describe('Testing max-depth behaviour', () => {
     let group = app.findAllComponents(QueryBuilderGroup)
       .wrappers
       .filter(g => g.vm.$props.depth === 3)
-      .shift() as Wrapper<QueryBuilderGroupInstance, Element>;
+      .shift() as Wrapper<QueryBuilderGroupInterface, Element>;
     expect(group.vm.groupControlSlotProps.maxDepthExeeded).toBeFalsy();
     // Assert button is present
     let button = group.find('.slot-new-group');
@@ -210,7 +210,7 @@ describe('Testing max-depth behaviour', () => {
     group = app.findAllComponents(QueryBuilderGroup)
       .wrappers
       .filter(g => g.vm.$props.depth === 4)
-      .shift() as Wrapper<QueryBuilderGroupInstance, Element>;
+      .shift() as Wrapper<QueryBuilderGroupInterface, Element>;
     expect(group.vm.groupControlSlotProps.maxDepthExeeded).toBeTruthy();
     // Assert button is absent
     button = group.find('.slot-new-group');
@@ -265,19 +265,41 @@ describe('Testing max-depth behaviour', () => {
     const group1 = (
         groups.filter(g => g.vm.$props.depth === 1)
           .shift()
-      ) as Wrapper<QueryBuilderGroupInstance, Element>;
-    expect((group1.vm as QueryBuilderGroupInstance).maxDepthExeeded).toBeFalsy();
+      ) as Wrapper<QueryBuilderGroupInterface, Element>;
+    expect((group1.vm as QueryBuilderGroupInterface).maxDepthExeeded).toBeFalsy();
     expect(group1.find('.query-builder-group__group-adding-button').exists()).toBeTruthy();
 
     const group4 = (
         groups.filter(g => g.vm.$props.depth === 4)
           .shift()
-      ) as Wrapper<QueryBuilderGroupInstance, Element>;
-    expect((group4.vm as QueryBuilderGroupInstance).maxDepthExeeded).toBeTruthy();
+      ) as Wrapper<QueryBuilderGroupInterface, Element>;
+    expect((group4.vm as QueryBuilderGroupInterface).maxDepthExeeded).toBeTruthy();
     expect(group4.find('.query-builder-group__group-adding-button').exists()).toBeFalsy();
   });
 
   it('checks and rejects movements, violating the max depth policy', () => {
+    const buildDragEl = (r: Rule | RuleSet, c: QueryBuilderConfig): HTMLElement => {
+      const rChild = shallowMount(QueryBuilderChild, {
+        propsData: {
+          query: { ...r },
+          config: { ...c },
+        },
+      });
+
+      const rEl = {
+        __vue__: rChild.vm,
+      } as unknown;
+
+      return rEl as HTMLElement;
+    };
+
+    const buildDragOptions = (ws: Array<Wrapper<Vue, Element>>): DragOptionsInstance => {
+      const w = ws.shift() as Wrapper<Vue, Element>;
+      const qbgi = w.vm as QueryBuilderGroupInterface;
+
+      return (qbgi.dragOptions as DragOptionsInstance);
+    };
+
     const app = mount(QueryBuilder, {
       propsData: {
         value: { ...value },
@@ -305,25 +327,3 @@ describe('Testing max-depth behaviour', () => {
     expect(dragOptions2.group.put(s, s, buildDragEl(movingRuleSet, config), se)).toBeFalsy();
   });
 });
-
-function buildDragEl(r: Rule | RuleSet, config: QueryBuilderConfig): HTMLElement {
-  const rChild = shallowMount(QueryBuilderChild, {
-    propsData: {
-      query: { ...r },
-      config: { ...config },
-    },
-  });
-
-  const rEl = {
-    __vue__: rChild.vm,
-  } as unknown;
-
-  return rEl as HTMLElement;
-}
-
-function buildDragOptions(ws: Array<Wrapper<Vue, Element>>): DragOptionsInstance {
-  const w = ws.shift() as Wrapper<Vue, Element>;
-  const qbgi = w.vm as QueryBuilderGroupInstance;
-
-  return (qbgi.dragOptions as DragOptionsInstance);
-}

--- a/tests/unit/max-depth.spec.ts
+++ b/tests/unit/max-depth.spec.ts
@@ -15,12 +15,12 @@ interface QueryBuilderGroupInstance extends Vue {
   dragOptions: SortableOptions,
 }
 
-interface GroupOptionsInterface extends GroupOptions {
+interface GroupOptionsInstance extends GroupOptions {
   put: ((to: Sortable, from: Sortable, dragEl: HTMLElement, event: SortableEvent) => PutResult)
 }
 
-interface DragOptionsInterface extends SortableOptions {
-  group: GroupOptionsInterface,
+interface DragOptionsInstance extends SortableOptions {
+  group: GroupOptionsInstance,
 }
 
 describe('Testing max-depth behaviour', () => {
@@ -252,9 +252,9 @@ function buildDragEl(r: Rule | RuleSet, config: QueryBuilderConfig): HTMLElement
   return rEl as HTMLElement;
 }
 
-function buildDragOptions(ws: Array<Wrapper<Vue, Element>>): DragOptionsInterface {
+function buildDragOptions(ws: Array<Wrapper<Vue, Element>>): DragOptionsInstance {
   const w = ws.shift() as Wrapper<Vue, Element>;
   const qbgi = w.vm as QueryBuilderGroupInstance;
 
-  return (qbgi.dragOptions as DragOptionsInterface);
+  return (qbgi.dragOptions as DragOptionsInstance);
 }

--- a/tests/unit/validation.spec.ts
+++ b/tests/unit/validation.spec.ts
@@ -1,80 +1,9 @@
-import { isQueryBuilderConfig, isRule, isRuleSet } from '@/guards';
+import {
+  isQueryBuilderConfig, isRule, isRuleSet, isOperatorDefinition, isRuleDefinition,
+} from '@/guards';
 import Component from '../components/Component.vue';
 
 describe('Testing component props and guards', () => {
-  it('checks isQueryBuilderConfig guard', () => {
-    // VALID
-    [
-      { // Default, minimal example with all valid combinations
-        operators: [
-          {
-            identifier: 'foo',
-            name: 'foo',
-          },
-        ],
-        rules: [
-          {
-            identifier: 'foo',
-            name: 'foo',
-            component: 'foo',
-          },
-          {
-            identifier: 'bar',
-            name: 'bar',
-            component: () => {},
-          },
-          {
-            identifier: 'baz',
-            name: 'baz',
-            component: Component,
-          },
-        ],
-      },
-
-      { // Only checking for valid colors
-        operators: [],
-        rules: [],
-        colors: ['foo', 'bar'],
-      },
-
-    ].forEach((t: any) => expect(isQueryBuilderConfig(t)).toBeTruthy());
-
-    // INVALID
-    [
-      null, // Check nulled parameter
-
-      { // Invalid operator
-        operators: [
-          {
-            identifier: 'foo',
-          },
-        ],
-        rules: [],
-      },
-
-      { // Invalid rule
-        operators: [
-        ],
-        rules: [
-          {
-            identifier: 'foo',
-            name: 'foo',
-            component: 123,
-          },
-        ],
-      },
-
-      { // Invalid color
-        operators: [],
-        rules: [],
-        colors: [
-          123,
-        ],
-      },
-    ].forEach((t: any) => expect(isQueryBuilderConfig(t)).toBeFalsy());
-    expect(isQueryBuilderConfig(null)).toBeFalsy();
-  });
-
   it('checks isRule guard', () => {
     // VALID
     [
@@ -132,5 +61,150 @@ describe('Testing component props and guards', () => {
       { operatorIdentifier: 'foo', children: [{ identifier: 123, value: null }, { operatorIdentifier: 'baz', children: [] }] },
       { operatorIdentifier: 'foo', children: [{ identifier: 'bar', value: null }, { operatorIdentifier: 'baz', children: 'invalid' }] },
     ].forEach((t: any) => expect(isRuleSet(t)).toBeFalsy());
+  });
+
+  it('checks isOperatorDefinition guards', () => {
+    // VALID
+    [
+      {
+        identifier: 'foo',
+        name: 'foo',
+      },
+    ].forEach((t: any) => expect(isOperatorDefinition(t)).toBeTruthy());
+
+    // INVALID
+    [
+      { name: 'bar' },
+      { identifier: 'bar' },
+      {},
+      [],
+      null,
+    ].forEach((t: any) => expect(isOperatorDefinition(t)).toBeFalsy());
+  });
+
+  it('checks isRuleDefinition guards', () => {
+    // VALID
+    [
+      {
+        identifier: 'foo',
+        name: 'foo',
+        component: 'foo',
+        initialValue: 'asdf',
+      },
+      {
+        identifier: 'bar',
+        name: 'bar',
+        component: () => {},
+      },
+      {
+        identifier: 'baz',
+        name: 'baz',
+        component: Component,
+      },
+    ].forEach((t: any) => expect(isRuleDefinition(t)).toBeTruthy());
+
+    // INVALID
+    [
+      {},
+      null,
+      [],
+      { name: 'baz', component: Component },
+      { identifier: 'baz', component: Component },
+      { identifier: 'baz', name: 'baz', component: 1234 },
+    ].forEach((t: any) => expect(isRuleDefinition(t)).toBeFalsy());
+  });
+
+  it('checks isQueryBuilderConfig guard', () => {
+    // VALID
+    [
+      { // Default, minimal example with all valid combinations
+        operators: [
+          {
+            identifier: 'foo',
+            name: 'foo',
+          },
+        ],
+        rules: [
+          {
+            identifier: 'foo',
+            name: 'foo',
+            component: 'foo',
+          },
+          {
+            identifier: 'bar',
+            name: 'bar',
+            component: () => {},
+          },
+          {
+            identifier: 'baz',
+            name: 'baz',
+            component: Component,
+          },
+        ],
+      },
+
+      { // Only checking for valid colors
+        operators: [],
+        rules: [],
+        colors: ['foo', 'bar'],
+      },
+
+      { // Only checking for maxDepth
+        operators: [],
+        rules: [],
+        maxDepth: undefined,
+      },
+      {
+        operators: [],
+        rules: [],
+        maxDepth: 10,
+      },
+    ].forEach((t: any) => expect(isQueryBuilderConfig(t)).toBeTruthy());
+
+    // INVALID
+    [
+      null, // Check nulled parameter
+
+      { // Invalid operator
+        operators: [
+          {
+            identifier: 'foo',
+          },
+        ],
+        rules: [],
+      },
+
+      { // Invalid rule
+        operators: [
+        ],
+        rules: [
+          {
+            identifier: 'foo',
+            name: 'foo',
+            component: 123,
+          },
+        ],
+      },
+
+      { // Invalid color
+        operators: [],
+        rules: [],
+        colors: [
+          123,
+        ],
+      },
+
+      { // Invalid maxDepth
+        operators: [],
+        rules: [],
+        maxDepth: -1,
+      },
+      {
+        operators: [],
+        rules: [],
+        maxDepth: 'asdf',
+      },
+    ].forEach((t: any) => expect(isQueryBuilderConfig(t)).toBeFalsy());
+    expect(isQueryBuilderConfig(null)).toBeFalsy();
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import Vue, { Component } from 'vue';
+import { Component } from 'vue';
 import { SortableOptions } from 'sortablejs';
 
 export interface Rule {
@@ -26,6 +26,7 @@ export interface RuleDefinition {
 export interface QueryBuilderConfig {
   operators: OperatorDefinition[],
   rules: RuleDefinition[],
+  maxDepth?: number,
   colors?: string[],
   dragging?: SortableOptions,
 }
@@ -37,6 +38,7 @@ export interface GroupOperatorSlotProps {
 }
 
 export interface GroupCtrlSlotProps {
+  maxDepthExeeded: boolean,
   rules: RuleDefinition[],
   addRule: (newRule: string) => void,
   newGroup: () => void,


### PR DESCRIPTION
Introduce new, optional setting `maxDepth`. This setting can be used to restrict maximum nesting of groups.

##### Configuration:
If `maxDepth` is `undefined`, users may have an arbitrary depth of nested groups. This reflects in the current behavior and is backwards compatible.  
If `typeof maxDepth === 'number'` and `0 <= n <= maxDepth`, users are only allowed to create up to n groups in deep. If n is 0, users are effectively not allowed to create any groups at all.

##### groupCtrlSlotProps:
For slots of type [`groupCtrlSlotProps`](https://rtucek.github.io/vue-query-builder/styling.html#groupcontrol-slot), the `newGroup()` callback, passed as slot prop, becomes a noop, if a group has exceeded the `maxDepth` policy. Additionally, a boolean flag with as `maxDepthExeeded` property is provided to the slot prop object, so the slot can apply some `v-if` condition logic for hiding a create-new-group handler.

##### Drag'n'drop:
Prior dropping a dragged group into another group, the library checks if the max depth policy would be violated and prevents dropping. The user will notice that the drag'n'drop preview will not adjust as usually expected.

##### Config change at runtime
It is possible and valid to change `maxDepth` at runtime. As a special chase, if the given `query` has a higher nested depth and a config change restricts the `maxDepth` to a lower depth, the library (intentionally) removes any child groups, exceeding the present config limit. This ensures consistency with the `maxDepth` policy. It's the component's parent responsibility of checking if setting `maxDepth` may not result in an unwanted side-effect of removing any children from the given query tree.

##### Bonus
`yarn serve`'s testing setup got a panel for quick config changes at runtime.

TODO:
- [x] Write unit tests
- [x] Write documentation (including codesandbox.io sample)

closes #61 