### PR TITLE
Revert code coverage report #65

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -38,8 +38,4 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Unit Test
-        uses: mattallty/jest-github-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          test-command: "yarn run test:unit"
+        run: yarn run test:unit


### PR DESCRIPTION
This reverts commit 5ec50796a4adee490d690fdb709e076d61069854, reversing
changes made to 93f5c226ec49a3ffb6351863fe52ca4f299cc435.

Revert necessary due to mattallty/jest-github-action#41.

It causes broken [builds](https://github.com/rtucek/vue-query-builder/runs/4342973704) on the master branch.