### PR TITLE
Fix Github workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,10 +3,10 @@ name: CI Build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test-build:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -3,10 +3,10 @@ name: CI Testing
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test-unit:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
Github Workflows are no longer firing.
This is due to having the default branch renamed from `master` to `main`.