### PR TITLE
Avoid string comparison for QueryBuilderGroup identification

### DIFF
--- a/src/MergeTrap.ts
+++ b/src/MergeTrap.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import {
+  QueryBuilderGroupSym,
   RuleSet, QueryBuilderGroup, ComponentRegistration, MergeTrap as MergeTrapInterface, Rule,
 } from '@/types';
 
@@ -12,7 +13,7 @@ function getNextGroup(group: QueryBuilderGroup): QueryBuilderGroup {
 
   do {
     vm = vm.$parent;
-  } while (vm.$options.name !== 'QueryBuilderGroup');
+  } while ((vm as QueryBuilderGroup).type !== QueryBuilderGroupSym);
 
   return vm as QueryBuilderGroup;
 }

--- a/src/QueryBuilderGroup.vue
+++ b/src/QueryBuilderGroup.vue
@@ -7,7 +7,7 @@ import Draggable, {
 } from 'vuedraggable';
 import Sortable, { SortableOptions, PutResult } from 'sortablejs';
 import {
-  QueryBuilderConfig, RuleSet, Rule, OperatorDefinition, RuleDefinition,
+  QueryBuilderConfig, RuleSet, Rule, OperatorDefinition, RuleDefinition, QueryBuilderGroupSym,
   GroupOperatorSlotProps, GroupCtrlSlotProps, QueryBuilderGroup as QueryBuilderGroupInterface,
 } from '@/types';
 import { isQueryBuilderConfig, isRule } from '@/guards';
@@ -79,7 +79,9 @@ export default class QueryBuilderGroup extends Vue implements QueryBuilderGroupI
 
   trap: ((position: number, newChild: RuleSet | Rule) => void) | null = null;
 
-  selectedRule: string = ''
+  selectedRule: string = '';
+
+  type: Symbol = QueryBuilderGroupSym;
 
   get children(): Array<RuleSet | Rule> {
     if (this.maxDepthExeeded) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,11 +50,14 @@ export interface RuleSlotProps {
   updateRuleData: (newData: any) => void,
 }
 
+export const QueryBuilderGroupSym = Symbol('QueryBuilderGroup');
+
 export interface QueryBuilderGroup extends Vue {
   selectedOperator: string,
   depth: number,
   trap: ((position: number, newChild: RuleSet | Rule) => void) | null,
   children: Array<RuleSet | Rule>,
+  type: Symbol,
 }
 
 export interface ComponentRegistration {


### PR DESCRIPTION
As reported by @ucuncuatabek [[1]](https://github.com/rtucek/vue-query-builder/issues/61#issuecomment-1005849690) and @janhorubala [[2]](https://github.com/dabernathy89/vue-query-builder/issues/70#issue-953708668), this is an attempt to fix odd drag'n'drop behaviour with production builds.