### PR TITLE
have rule identifier available in RuleSlot

### DIFF
--- a/src/QueryBuilderRule.vue
+++ b/src/QueryBuilderRule.vue
@@ -43,6 +43,7 @@ export default class QueryBuilderRule extends Vue {
     return {
       ruleComponent: this.component,
       ruleData: this.query.value,
+      ruleIdentifier: this.query.identifier,
       updateRuleData: (ruleData: any) => this.ruleUpdate(ruleData),
     };
   }


### PR DESCRIPTION
This PR adds the ruleIdentifier to the RuleSlot Props to cleraly identify the exact rule that is being used. Related to Issue #81