### PR TITLE
Remove code coverage upload in PRs

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -39,9 +39,3 @@ jobs:
 
       - name: Unit Test
         run: yarn run test:unit --coverage --collectCoverageOnlyFrom ./src/**
-
-      - name: Report coverage
-        uses: vebr/jest-lcov-reporter@v0.2.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          update-comment: true


### PR DESCRIPTION
As seen in #83, code coverage upload as a comment in the PR doesn't work if the PR is opened by
someone without direct write access to this repository.

This is due to a [limitation in Github Actions](https://github.community/t/github-actions-are-severely-limited-on-prs/18179#M9249).